### PR TITLE
Use relative paths and add vite config

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,13 +3,13 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <link rel="manifest" href="/manifest.json" />
-  <link rel="stylesheet" href="/src/styles.css" />
+  <link rel="manifest" href="./manifest.json" />
+  <link rel="stylesheet" href="./src/styles.css" />
   <title>PWA Sample</title>
 </head>
 <body>
   <h1>PWA Sample</h1>
   <p id="status">Loading...</p>
-  <script type="module" src="/src/main.js"></script>
+  <script type="module" src="./src/main.js"></script>
 </body>
 </html>

--- a/src/main.js
+++ b/src/main.js
@@ -1,6 +1,6 @@
 if ('serviceWorker' in navigator) {
   window.addEventListener('load', () => {
-    navigator.serviceWorker.register('/sw.js').then(reg => {
+    navigator.serviceWorker.register('./sw.js').then(reg => {
       console.log('SW registered', reg);
       if (reg.waiting) reg.waiting.postMessage({ type: 'SKIP_WAITING' });
       reg.addEventListener('updatefound', () => {

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,3 @@
+export default {
+  base: './'
+}


### PR DESCRIPTION
## Summary
- reference manifest, CSS, and JS with relative paths in `index.html`
- register service worker using a relative path
- add `vite.config.js` so built assets use relative URLs

## Testing
- `npm run build`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6849063041c88331b07007a69073c9be