### PR TITLE
Fix relative service worker paths

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,13 +3,13 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <link rel="manifest" href="./manifest.json" />
-  <link rel="stylesheet" href="./src/styles.css" />
+  <link rel="manifest" href="manifest.json" />
+  <link rel="stylesheet" href="src/styles.css" />
   <title>PWA Sample</title>
 </head>
 <body>
   <h1>PWA Sample</h1>
   <p id="status">Loading...</p>
-  <script type="module" src="./src/main.js"></script>
+  <script type="module" src="src/main.js"></script>
 </body>
 </html>

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,8 +1,8 @@
 const CACHE_NAME = 'app-cache-v1';
 const ASSETS = [
-  '/',
-  '/index.html',
-  '/manifest.json'
+  './',
+  './index.html',
+  './manifest.json'
 ];
 
 self.addEventListener('install', (event) => {

--- a/src/main.js
+++ b/src/main.js
@@ -1,6 +1,6 @@
 if ('serviceWorker' in navigator) {
   window.addEventListener('load', () => {
-    navigator.serviceWorker.register('./sw.js').then(reg => {
+    navigator.serviceWorker.register('sw.js').then(reg => {
       console.log('SW registered', reg);
       if (reg.waiting) reg.waiting.postMessage({ type: 'SKIP_WAITING' });
       reg.addEventListener('updatefound', () => {


### PR DESCRIPTION
## Summary
- convert HTML asset links to relative paths
- register service worker using `sw.js`
- update asset list in `sw.js` for subdirectory hosting

## Testing
- `npm install`
- `npm run build`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68490e7047548331861759c20fec7f81