### PR TITLE
Fix caching logic in sw.js

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -26,7 +26,11 @@ self.addEventListener('fetch', (event) => {
     event.respondWith(
       caches.match(request).then(cachedResponse => {
         const fetchPromise = fetch(request).then(networkResponse => {
-          caches.open(CACHE_NAME).then(cache => cache.put(request, networkResponse.clone()));
+          if (networkResponse.ok) {
+            caches.open(CACHE_NAME).then(cache =>
+              cache.put(request, networkResponse.clone())
+            );
+          }
           return networkResponse;
         });
         return cachedResponse || fetchPromise;


### PR DESCRIPTION
## Summary
- ensure `sw.js` caches network responses only if `response.ok` is true

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68492f49d5608331a3452cd983ad2285