### PR TITLE
Fix Response cloning in service worker

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -27,8 +27,9 @@ self.addEventListener('fetch', (event) => {
       caches.match(request).then(cachedResponse => {
         const fetchPromise = fetch(request).then(networkResponse => {
           if (networkResponse.ok) {
+            const responseClone = networkResponse.clone();
             caches.open(CACHE_NAME).then(cache =>
-              cache.put(request, networkResponse.clone())
+              cache.put(request, responseClone)
             );
           }
           return networkResponse;


### PR DESCRIPTION
## Summary
- avoid `Response` reuse error by cloning before caching

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6849338b3e0c83319384ee460eb49ed3