### PR TITLE
Implement scroll-based bar visibility

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -22,3 +22,50 @@ if ('serviceWorker' in navigator) {
     });
   });
 }
+
+function throttle(fn, delay) {
+  let last = 0;
+  return (...args) => {
+    const now = Date.now();
+    if (now - last >= delay) {
+      last = now;
+      fn(...args);
+    }
+  };
+}
+
+function initScrollVisibility() {
+  const topbar = document.getElementById('topbar');
+  const bottombar = document.getElementById('bottombar');
+  if (!topbar || !bottombar) return;
+
+  let lastY = window.scrollY;
+  let accumulated = 0;
+  const THRESHOLD = 50;
+
+  const onScroll = throttle(() => {
+    const currentY = window.scrollY;
+    const diff = currentY - lastY;
+    lastY = currentY;
+
+    if (Math.sign(diff) !== Math.sign(accumulated)) {
+      accumulated = diff;
+    } else {
+      accumulated += diff;
+    }
+
+    if (accumulated > THRESHOLD) {
+      topbar.classList.add('hidden');
+      bottombar.classList.add('hidden');
+      accumulated = 0;
+    } else if (accumulated < -THRESHOLD) {
+      topbar.classList.remove('hidden');
+      bottombar.classList.remove('hidden');
+      accumulated = 0;
+    }
+  }, 100);
+
+  window.addEventListener('scroll', onScroll, { passive: true });
+}
+
+window.addEventListener('DOMContentLoaded', initScrollVisibility);

--- a/src/styles.css
+++ b/src/styles.css
@@ -19,10 +19,10 @@ body {
   bottom: 0;
 }
 
-.hidden-top {
+#topbar.hidden {
   transform: translateY(-100%);
 }
 
-.hidden-bottom {
+#bottombar.hidden {
   transform: translateY(100%);
 }


### PR DESCRIPTION
## Summary
- hide header and footer when scrolling down quickly
- show header and footer when scrolling up
- throttle scroll events for performance
- add `.hidden` CSS rules for header and footer

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6849373926308331aa83cdc07e68b27e