### PR TITLE
Add offline page and improve service worker

### DIFF
--- a/offline.html
+++ b/offline.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Offline</title>
+  <link rel="stylesheet" href="src/styles.css" />
+</head>
+<body>
+  <main>
+    <h1>Offline</h1>
+    <p>You are currently offline. Please check your connection.</p>
+  </main>
+</body>
+</html>

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'app-cache-v1';
+const CACHE_NAME = 'app-cache-v2';
 
 const PAGES = [
   './index.html',
@@ -11,6 +11,7 @@ const PAGES = [
 const ASSETS = [
   './',
   ...PAGES,
+  './offline.html',
   './manifest.json',
   './src/main.js',
   './src/styles.css',
@@ -34,6 +35,15 @@ self.addEventListener('activate', (event) => {
 
 self.addEventListener('fetch', (event) => {
   const { request } = event;
+  if (request.mode === 'navigate') {
+    event.respondWith(
+      fetch(request)
+        .catch(() =>
+          caches.match(request).then(resp => resp || caches.match('./offline.html'))
+        )
+    );
+    return;
+  }
   if (request.destination === 'style' || request.destination === 'script') {
     event.respondWith(
       caches.match(request).then(cachedResponse => {


### PR DESCRIPTION
## Summary
- add simple `offline.html`
- cache `offline.html` during install
- serve `offline.html` when navigation fails

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684941b541488331ad64239986a52afd