### PR TITLE
Add small-screen header height media query

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -100,3 +100,9 @@ main {
 .offline-container button:hover {
   filter: brightness(1.1);
 }
+
+@media (max-width: 480px) {
+  :root {
+    --header-height: 120px;
+  }
+}


### PR DESCRIPTION
## Summary
- add CSS media query that increases `--header-height` when the screen width is 480px or less

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684a345e0e508331a7e742a7c4b5adf1