### PR TITLE
Remove Google Fonts

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,9 +5,6 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="theme-color" content="#00d2ff" />
   <link rel="manifest" href="manifest.json" />
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700&family=Roboto:wght@300;400&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="src/styles.css" />
   <title>PWA Sample</title>
 </head>

--- a/offline.html
+++ b/offline.html
@@ -4,9 +4,6 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Offline</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700&family=Roboto:wght@300;400&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="src/styles.css" />
 </head>
 <body>

--- a/page2.html
+++ b/page2.html
@@ -5,9 +5,6 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="theme-color" content="#00d2ff" />
   <link rel="manifest" href="manifest.json" />
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700&family=Roboto:wght@300;400&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="src/styles.css" />
   <title>PWA Sample</title>
 </head>

--- a/page3.html
+++ b/page3.html
@@ -5,9 +5,6 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="theme-color" content="#00d2ff" />
   <link rel="manifest" href="manifest.json" />
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700&family=Roboto:wght@300;400&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="src/styles.css" />
   <title>PWA Sample</title>
 </head>

--- a/page4.html
+++ b/page4.html
@@ -5,9 +5,6 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="theme-color" content="#00d2ff" />
   <link rel="manifest" href="manifest.json" />
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700&family=Roboto:wght@300;400&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="src/styles.css" />
   <title>PWA Sample</title>
 </head>

--- a/page5.html
+++ b/page5.html
@@ -5,9 +5,6 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="theme-color" content="#00d2ff" />
   <link rel="manifest" href="manifest.json" />
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700&family=Roboto:wght@300;400&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="src/styles.css" />
   <title>PWA Sample</title>
 </head>

--- a/src/styles.css
+++ b/src/styles.css
@@ -6,7 +6,7 @@
 }
 
 body {
-  font-family: 'Roboto', sans-serif;
+  font-family: system-ui, sans-serif;
   margin: 0;
   min-height: 100vh;
   padding: var(--header-height) 20px 60px;
@@ -17,7 +17,7 @@ body {
 
 header,
 footer {
-  font-family: 'Orbitron', sans-serif;
+  font-family: system-ui, sans-serif;
   background: linear-gradient(to right, #1f1c2c, #928dab);
   color: #fff;
   padding: 10px 20px;


### PR DESCRIPTION
## Summary
- use system fonts instead of Google-hosted Roboto/Orbitron
- remove Google Fonts `<link>` tags from all HTML pages

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684a3cd0149883318e186abf5421dee3